### PR TITLE
Add `data_` arg to the `getOutboundCalldata()` method

### DIFF
--- a/contracts/arbitrum/InterchainERC20TokenGateway.sol
+++ b/contracts/arbitrum/InterchainERC20TokenGateway.sol
@@ -55,7 +55,8 @@ abstract contract InterchainERC20TokenGateway is
         address l1Token_,
         address from_,
         address to_,
-        uint256 amount_
+        uint256 amount_,
+        bytes memory // data_
     ) public pure returns (bytes memory) {
         return
             abi.encodeWithSelector(

--- a/contracts/arbitrum/L1ERC20TokenGateway.sol
+++ b/contracts/arbitrum/L1ERC20TokenGateway.sol
@@ -69,7 +69,8 @@ contract L1ERC20TokenGateway is
             l1Token,
             from,
             to_,
-            amount_
+            amount_,
+            ""
         );
 
         uint256 retryableTicketId = sendCrossDomainMessage(

--- a/contracts/arbitrum/L2ERC20TokenGateway.sol
+++ b/contracts/arbitrum/L2ERC20TokenGateway.sol
@@ -60,7 +60,7 @@ contract L2ERC20TokenGateway is
         uint256 id = sendCrossDomainMessage(
             from,
             counterpartGateway,
-            getOutboundCalldata(l1Token_, from, to_, amount_)
+            getOutboundCalldata(l1Token_, from, to_, amount_, "")
         );
 
         // The current implementation doesn't support fast withdrawals, so we

--- a/contracts/arbitrum/README.md
+++ b/contracts/arbitrum/README.md
@@ -331,7 +331,7 @@ All variables are declared as `immutable` to reduce transactions gas costs.
 
 Returns an address of token, which will be minted on the Arbitrum chain, on `l1Token_` bridging. The current implementation returns the `l2Token` address when passed `l1Token_` equals to `l1Token` declared in the contract and `address(0)` in other cases.
 
-#### `getOutboundCalldata(address,address,address,uint256)`
+#### `getOutboundCalldata(address,address,address,uint256,bytes memory)`
 
 > **Visibility:** &nbsp;&nbsp;&nbsp; `public`
 >
@@ -345,6 +345,7 @@ Returns an address of token, which will be minted on the Arbitrum chain, on `l1T
 > - **`from_`** - an address in the Ethereum chain of the account initiated bridging
 > - **`to_`** - an address in the Ethereum chain of the recipient of the token on the corresponding chain
 > - **`amount_`** - an amount of tokens to bridge
+> - **`data_`** - Custom data to pass into finalizeInboundTransfer method. Unused, required to be compatible with @arbitrum/sdk package.
 
 Returns encoded transaction data to send into the corresponding gateway to finalize the tokens bridging process. The result of this method might be used to estimate the amount of ether required to pass to the `outboundTransfer()` method call. In the current implementation returns the transaction data of `finalizeInboundTransfer(token_, from_, to_, amount_)`.
 
@@ -422,7 +423,7 @@ Initiates the tokens bridging from the Ethereum into the Arbitrum chain. Escrows
 ```solidity=
 sendCrossDomainMessage(
     counterpartGateway, // recipient
-    getOutboundCalldata(l1Token, from, to, amount), // data
+    getOutboundCalldata(l1Token, from, to, amount, ""), // data
     CrossDomainMessageOptions({
         maxGas: maxGas,
         callValue: 0,
@@ -534,7 +535,7 @@ Initiates the withdrawing process from the Arbitrum chain into the Ethereum chai
 ```solidity=
 sendCrossDomainMessage(
     counterpartGateway,
-    getOutboundCalldata(l1Token_, from_, to_, amount_)
+    getOutboundCalldata(l1Token_, from_, to_, amount_, "")
 );
 ```
 

--- a/contracts/arbitrum/interfaces/IInterchainTokenGateway.sol
+++ b/contracts/arbitrum/interfaces/IInterchainTokenGateway.sol
@@ -38,11 +38,13 @@ interface IInterchainTokenGateway {
     /// @param from_ Address of the account initiated bridging in the current chain
     /// @param to_ Address of the recipient of the token in the counterpart chain
     /// @param amount_  Amount of tokens to bridge
+    /// @param data_  Custom data to pass into finalizeInboundTransfer method
     /// @return Encoded transaction data of finalizeInboundTransfer call
     function getOutboundCalldata(
         address l1Token_,
         address from_,
         address to_,
-        uint256 amount_
+        uint256 amount_,
+        bytes memory data_
     ) external view returns (bytes memory);
 }

--- a/test/arbitrum/L1ERC20TokensGateway.unit.test.ts
+++ b/test/arbitrum/L1ERC20TokensGateway.unit.test.ts
@@ -13,7 +13,7 @@ import {
 import { assert } from "chai";
 import { testsuite } from "../../utils/testing";
 
-testsuite("Arbitrum :: L1ERC20TokensGateway unit tests", ctxProvider, (ctx) => {
+testsuite("Arbitrum :: L1ERC20TokenGateway unit tests", ctxProvider, (ctx) => {
   it("l1Token() returns correct value after deployment", async () => {
     assert.equal(
       await ctx.l1TokensGateway.l1Token(),
@@ -64,7 +64,8 @@ testsuite("Arbitrum :: L1ERC20TokensGateway unit tests", ctxProvider, (ctx) => {
       ctx.stubs.l1Token.address,
       sender.address,
       recipient.address,
-      amount
+      amount,
+      "0x"
     );
 
     const expectedCalldata =

--- a/test/arbitrum/L2ERC20TokensGateway.unit.test.ts
+++ b/test/arbitrum/L2ERC20TokensGateway.unit.test.ts
@@ -66,7 +66,8 @@ testsuite("Arbitrum :: L2ERC20TokensGateway unit tests", ctxProvider, (ctx) => {
       l1Token.address,
       sender.address,
       recipient.address,
-      amount
+      amount,
+      "0x"
     );
 
     const expectedCalldata = l1TokensGateway.interface.encodeFunctionData(


### PR DESCRIPTION
The `data_` arg in the `getOutboundCalldata` method is required only for compatibility of the gateway with the `@arbitrum\sdk` package and doesn't impact the method logic.