### PR TITLE
Forbid bridging to zero address recipients

### DIFF
--- a/contracts/BridgeableTokens.sol
+++ b/contracts/BridgeableTokens.sol
@@ -35,6 +35,15 @@ contract BridgeableTokens {
         _;
     }
 
+    /// @dev validates that account_ is not zero address
+    modifier onlyNonZeroAccount(address account_) {
+        if (account_ == address(0)) {
+            revert ErrorAccountIsZeroAddress();
+        }
+        _;
+    }
+
     error ErrorUnsupportedL1Token();
     error ErrorUnsupportedL2Token();
+    error ErrorAccountIsZeroAddress();
 }

--- a/contracts/arbitrum/L1ERC20TokenGateway.sol
+++ b/contracts/arbitrum/L1ERC20TokenGateway.sol
@@ -55,6 +55,7 @@ contract L1ERC20TokenGateway is
         external
         payable
         whenDepositsEnabled
+        onlyNonZeroAccount(to_)
         onlySupportedL1Token(l1Token_)
         returns (bytes memory)
     {
@@ -65,17 +66,10 @@ contract L1ERC20TokenGateway is
 
         IERC20(l1Token_).safeTransferFrom(from, address(this), amount_);
 
-        bytes memory messageData = getOutboundCalldata(
-            l1Token,
+        uint256 retryableTicketId = _sendOutboundTransferMessage(
             from,
             to_,
-            amount_
-        );
-
-        uint256 retryableTicketId = sendCrossDomainMessage(
-            from,
-            counterpartGateway,
-            messageData,
+            amount_,
             CrossDomainMessageOptions({
                 maxGas: maxGas_,
                 callValue: 0,
@@ -107,5 +101,20 @@ contract L1ERC20TokenGateway is
         // The current implementation doesn't support fast withdrawals, so we
         // always use 0 for the exitNum argument in the event
         emit WithdrawalFinalized(l1Token_, from_, to_, 0, amount_);
+    }
+
+    function _sendOutboundTransferMessage(
+        address from_,
+        address to_,
+        uint256 amount_,
+        CrossDomainMessageOptions memory messageOptions
+    ) private returns (uint256) {
+        return
+            sendCrossDomainMessage(
+                from_,
+                counterpartGateway,
+                getOutboundCalldata(l1Token, from_, to_, amount_),
+                messageOptions
+            );
     }
 }

--- a/contracts/optimism/L1ERC20TokenBridge.sol
+++ b/contracts/optimism/L1ERC20TokenBridge.sol
@@ -70,6 +70,7 @@ contract L1ERC20TokenBridge is
     )
         external
         whenDepositsEnabled
+        onlyNonZeroAccount(to_)
         onlySupportedL1Token(l1Token_)
         onlySupportedL2Token(l2Token_)
     {

--- a/contracts/token/ERC20Core.sol
+++ b/contracts/token/ERC20Core.sol
@@ -163,13 +163,13 @@ contract ERC20Core is IERC20 {
     /// @dev validates that account_ is not zero address
     modifier onlyNonZeroAccount(address account_) {
         if (account_ == address(0)) {
-            revert ErrorZeroAddress();
+            revert ErrorAccountIsZeroAddress();
         }
         _;
     }
 
-    error ErrorZeroAddress();
     error ErrorNotEnoughBalance();
     error ErrorNotEnoughAllowance();
+    error ErrorAccountIsZeroAddress();
     error ErrorDecreasedAllowanceBelowZero();
 }

--- a/test/BridgingManager.unit.test.ts
+++ b/test/BridgingManager.unit.test.ts
@@ -84,7 +84,7 @@ testsuite("BridgingManager unit tests", ctxBuilder, (ctx) => {
     const tx = await bridgingManager.connect(depositsEnabler).enableDeposits();
 
     // validate that DepositsEnabled(enabler) event was emitted
-    assert.emits(bridgingManager, tx, "DepositsEnabled", [
+    await assert.emits(bridgingManager, tx, "DepositsEnabled", [
       depositsEnabler.address,
     ]);
 
@@ -156,7 +156,7 @@ testsuite("BridgingManager unit tests", ctxBuilder, (ctx) => {
       .disableDeposits();
 
     // validate that DepositsDisabled(disabler) event was emitted
-    assert.emits(bridgingManager, tx, "DepositsDisabled", [
+    await assert.emits(bridgingManager, tx, "DepositsDisabled", [
       depositsDisabler.address,
     ]);
 
@@ -206,7 +206,7 @@ testsuite("BridgingManager unit tests", ctxBuilder, (ctx) => {
       .enableWithdrawals();
 
     // validate that WithdrawalsEnabled(enabler) event was emitted
-    assert.emits(bridgingManager, tx, "WithdrawalsEnabled", [
+    await assert.emits(bridgingManager, tx, "WithdrawalsEnabled", [
       withdrawalsEnabler.address,
     ]);
 
@@ -278,7 +278,7 @@ testsuite("BridgingManager unit tests", ctxBuilder, (ctx) => {
       .disableWithdrawals();
 
     // validate that WithdrawalsDisabled(disabler) event was emitted
-    assert.emits(bridgingManager, tx, "WithdrawalsDisabled", [
+    await assert.emits(bridgingManager, tx, "WithdrawalsDisabled", [
       withdrawalsDisabler.address,
     ]);
 

--- a/test/arbitrum/L1ERC20TokensGateway.unit.test.ts
+++ b/test/arbitrum/L1ERC20TokensGateway.unit.test.ts
@@ -94,7 +94,7 @@ testsuite("Arbitrum :: L1ERC20TokensGateway unit tests", ctxProvider, (ctx) => {
     const data = encodeSenderOutboundTransferData(maxSubmissionCost);
 
     // validate deposit reverts with error ErrorDepositsDisabled()
-    assert.revertsWith(
+    await assert.revertsWith(
       ctx.l1TokensGateway
         .connect(sender)
         .outboundTransfer(

--- a/test/arbitrum/L1ERC20TokensGateway.unit.test.ts
+++ b/test/arbitrum/L1ERC20TokensGateway.unit.test.ts
@@ -209,6 +209,59 @@ testsuite("Arbitrum :: L1ERC20TokensGateway unit tests", ctxProvider, (ctx) => {
     );
   });
 
+  it("outboundTransfer() :: recipient is zero address", async () => {
+    const {
+      l1TokensGateway,
+      stubs: { l1Token },
+      accounts: { deployer, l1RouterAsEOA, sender },
+    } = ctx;
+
+    // initialize gateway
+    await l1TokensGateway.initialize(deployer.address);
+
+    // validate gateway was initialized
+    assert.isTrue(await l1TokensGateway.isInitialized());
+
+    // grant DEPOSITS_ENABLER_ROLE to the l1Deployer to enable deposits
+    await l1TokensGateway.grantRole(
+      await l1TokensGateway.DEPOSITS_ENABLER_ROLE(),
+      deployer.address
+    );
+
+    // enable deposits
+    await l1TokensGateway.enableDeposits();
+
+    // validate deposits was enabled
+    assert.isTrue(await l1TokensGateway.isDepositsEnabled());
+
+    const amount = wei`1.2 ether`;
+    const maxGas = wei`1000 gwei`;
+    const gasPriceBid = wei`2000 gwei`;
+    const maxSubmissionCost = wei`11_000 gwei`;
+    const value = wei`3000 gwei`;
+    const data = encodeRouterOutboundTransferData(
+      sender.address,
+      maxSubmissionCost,
+      "0xdeadbeef"
+    );
+
+    // initiate outbound transfer
+    await assert.revertsWith(
+      l1TokensGateway
+        .connect(l1RouterAsEOA)
+        .outboundTransfer(
+          l1Token.address,
+          ethers.constants.AddressZero,
+          amount,
+          maxGas,
+          gasPriceBid,
+          data,
+          { value }
+        ),
+      "ErrorAccountIsZeroAddress()"
+    );
+  });
+
   it("outboundTransfer() :: called by router", async () => {
     const {
       l1TokensGateway,

--- a/test/arbitrum/L2ERC20TokensGateway.unit.test.ts
+++ b/test/arbitrum/L2ERC20TokensGateway.unit.test.ts
@@ -91,8 +91,8 @@ testsuite("Arbitrum :: L2ERC20TokensGateway unit tests", ctxProvider, (ctx) => {
     const maxSubmissionCost = wei`11_000 gwei`;
     const data = encodeOutboundTransferData(maxSubmissionCost);
 
-    // validate deposit reverts with error ErrorDepositsDisabled()
-    assert.revertsWith(
+    // validate deposit reverts with error ErrorWithdrawalsDisabled()
+    await assert.revertsWith(
       l2TokensGateway
         .connect(sender)
         .outboundTransfer(
@@ -103,7 +103,7 @@ testsuite("Arbitrum :: L2ERC20TokensGateway unit tests", ctxProvider, (ctx) => {
           gasPriceBid,
           data
         ),
-      "ErrorDepositsDisabled()"
+      "ErrorWithdrawalsDisabled()"
     );
   });
 

--- a/test/optimism/L1ERC20TokenBridge.unit.test.ts
+++ b/test/optimism/L1ERC20TokenBridge.unit.test.ts
@@ -1,5 +1,5 @@
 import { assert } from "chai";
-import hre from "hardhat";
+import hre, { ethers } from "hardhat";
 import {
   ERC20BridgedStub__factory,
   L1ERC20TokenBridge__factory,
@@ -206,6 +206,26 @@ testsuite("Optimism :: L1ERC20TokenBridge unit tests", ctxProvider, (ctx) => {
         "0x"
       ),
       "ErrorDepositsDisabled()"
+    );
+  });
+
+  it("depositsERC20To() :: recipient is zero address", async () => {
+    const {
+      l1TokenBridge,
+      stubs: { l1Token },
+      accounts: { stranger },
+    } = ctx;
+
+    await assert.revertsWith(
+      l1TokenBridge.depositERC20To(
+        l1Token.address,
+        stranger.address,
+        ethers.constants.AddressZero,
+        wei`1 ether`,
+        wei`1 gwei`,
+        "0x"
+      ),
+      "ErrorAccountIsZeroAddress()"
     );
   });
 

--- a/test/token/ERC20Bridged.unit.test.ts
+++ b/test/token/ERC20Bridged.unit.test.ts
@@ -86,17 +86,17 @@ testsuite("ERC20Bridged unit tests", ctxProvider, (ctx) => {
     const {
       accounts: { zero, recipient },
     } = ctx;
-    assert.revertsWith(
+    await assert.revertsWith(
       ctx.erc20Bridged.connect(zero).transfer(recipient.address, wei`1 ether`),
-      "ErrorZeroAddress()"
+      "ErrorAccountIsZeroAddress()"
     );
   });
 
   it("transfer() :: recipient is zero address", async () => {
     const { zero, holder } = ctx.accounts;
-    assert.revertsWith(
+    await assert.revertsWith(
       ctx.erc20Bridged.connect(holder).transfer(zero.address, wei`1 ether`),
-      "ErrorZeroAddress()"
+      "ErrorAccountIsZeroAddress()"
     );
   });
 
@@ -126,7 +126,7 @@ testsuite("ERC20Bridged unit tests", ctxProvider, (ctx) => {
     const amount = wei.toBigNumber(premint).add(wei`1 ether`);
 
     // transfer tokens
-    assert.revertsWith(
+    await assert.revertsWith(
       erc20Bridged.connect(holder).transfer(recipient.address, amount),
       "ErrorNotEnoughBalance()"
     );


### PR DESCRIPTION
Bridging to the zero address accounts will fail on the L2 side because `ERC20Bridged` token forbids minting to the zero address. Even though such bridge usage is very low-probable, it's better to prohibit such bridge operations on the L1 side.