### PR TITLE
chore: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns: ["*"]
+    labels: ["dependencies", "github-actions"]
+    commit-message:
+      prefix: "ci"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      javascript:
+        patterns: ["*"]
+    labels: ["dependencies", "javascript"]
+    commit-message:
+      prefix: "build"
+      include: "scope"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      python:
+        patterns: ["*"]
+    labels: ["dependencies", "python"]
+    commit-message:
+      prefix: "build"
+      include: "scope"

--- a/.github/workflows/analyse.yml
+++ b/.github/workflows/analyse.yml
@@ -14,10 +14,10 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup node.js version
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 16.x
           cache: "npm"
@@ -25,7 +25,7 @@ jobs:
       - name: Install node deps
         run: npm ci
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.10.6"
 
@@ -48,7 +48,7 @@ jobs:
           echo 'value=not' >> $GITHUB_OUTPUT
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         if: ${{ always() && steps.results.outputs.value == 'present' }}
         with:
           sarif_file: results.sarif
@@ -57,10 +57,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup node.js version
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 16.x
 

--- a/.github/workflows/verify-bytecode.yml
+++ b/.github/workflows/verify-bytecode.yml
@@ -11,18 +11,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
       - name: Setup node.js version
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 16
 
       - name: Cache node_modules
         id: cache-node-modules
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: "**/node_modules"
           key: node_modules-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
Adds a Dependabot configuration for weekly grouped dependency updates:

- `github-actions`: weekly, grouped, 7-day cooldown
- `npm`: weekly, all dependencies grouped, 7-day cooldown
- `pip` (poetry): weekly, all dependencies grouped, 7-day cooldown

Also pins all workflow actions to commit hashes and bumps them to latest releases:

| Action | Before | After |
|---|---|---|
| actions/checkout | v3 | v6.0.3 |
| actions/setup-node | v3 | v6.4.0 |
| actions/setup-python | v4 | v6.2.0 |
| actions/cache | v3 | v5.0.5 |
| github/codeql-action/upload-sarif | v2 | v4.36.2 |